### PR TITLE
Fix infinite loop in getFullList

### DIFF
--- a/src/commonMain/kotlin/io/github/agrevster/pocketbaseKotlin/services/utils/BaseCrudService.kt
+++ b/src/commonMain/kotlin/io/github/agrevster/pocketbaseKotlin/services/utils/BaseCrudService.kt
@@ -31,7 +31,7 @@ public abstract class BaseCrudService<T : BaseModel>(client: io.github.agrevster
             val list = _getList<T>(path, page, batch, sortBy, filterBy, expandRelations, showFields, skipTotal)
             val items = list.items.toMutableList()
             result.addAll(items)
-            if (items.isNotEmpty() && list.totalItems <= result.size) return result
+            if (list.perPage != items.size) return result
             page += 1
         }
     }


### PR DESCRIPTION
Sometimes Pocketbase returns -1 for `totalItems`. This code matches [js-sdk](https://github.com/pocketbase/js-sdk/blob/98b5fa014a27b88a6f25d39d741b10f821d0a24a/src/services/utils/CrudService.ts#L196)