### PR TITLE
Allow passing a custom Json instance to parseRecord

### DIFF
--- a/src/commonMain/kotlin/io/github/agrevster/pocketbaseKotlin/services/RealtimeService.kt
+++ b/src/commonMain/kotlin/io/github/agrevster/pocketbaseKotlin/services/RealtimeService.kt
@@ -26,9 +26,9 @@ public class RealtimeService(client: PocketbaseClient) : BaseService(client) {
          * Serializes the record emitted to type [T] Used to get the record from an
          * event
          */
-        public inline fun <reified T> parseRecord(): T {
+        public inline fun <reified T> parseRecord(json: Json = Json): T {
             if (action == RealtimeActionType.CONNECT) throw PocketbaseException("Connect event cannot be parsed!")
-            return Json.decodeFromJsonElement(record!!)
+            return json.decodeFromJsonElement(record!!)
         }
     }
 

--- a/src/commonMain/kotlin/io/github/agrevster/pocketbaseKotlin/services/RealtimeService.kt
+++ b/src/commonMain/kotlin/io/github/agrevster/pocketbaseKotlin/services/RealtimeService.kt
@@ -25,6 +25,7 @@ public class RealtimeService(client: PocketbaseClient) : BaseService(client) {
         /**
          * Serializes the record emitted to type [T] Used to get the record from an
          * event
+         * @param [json] An optional custom Json parser
          */
         public inline fun <reified T> parseRecord(json: Json = Json): T {
             if (action == RealtimeActionType.CONNECT) throw PocketbaseException("Connect event cannot be parsed!")


### PR DESCRIPTION
This allows `MessageData#parseRecord` to be called with an optional `Json` instance, which gives the user some flexibility about how the MessageData is decoded, such as
```kotlin
val record = parseRecord<Record>(Json { ignoreUnknownKeys = true })
```
This example is useful for cases where it has to be determined which collection a record is from before it can be properly decoded.