### PR TITLE
feat: support wasmJs

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,6 @@
+@file:OptIn(ExperimentalWasmDsl::class)
+
+import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
 import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSet
 
 plugins {
@@ -50,6 +53,10 @@ kotlin {
     androidNativeX64()
     androidNativeX86()
 
+    wasmJs {
+        browser()
+        nodejs()
+    }
 
     sourceSets {
         commonMain {
@@ -106,6 +113,20 @@ kotlin {
             }
         }
 
+        val jsMain by creating {
+            dependsOn(commonMain.get())
+            dependencies {
+                api(libs.ktor.client.js)
+                api(libs.kotlin.coroutines)
+            }
+        }
+        val jsTest by creating {
+            dependsOn(commonTest.get())
+            dependencies {
+                implementation(libs.ktor.client.js)
+                api(libs.kotlin.coroutines)
+            }
+        }
 
         fun KotlinSourceSet.configureDependencies(
             test: Boolean = false,
@@ -163,6 +184,9 @@ kotlin {
 
         getByName("androidNativeX86Main").configureDependencies()
         getByName("androidNativeX86Test").configureDependencies(test = true)
+
+        getByName("wasmJsMain").dependsOn(jsMain)
+        getByName("wasmJsTest").dependsOn(jsTest)
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ kotlin.native.ignoreDisabledTargets=true
 kotlin.parallel.tasks.in.project=true
 kotlin.incremental.multiplatform=true
 GROUP=io.github.agrevster
-VERSION=2.7.1
+VERSION=2.7.2
 kotlin.mpp.applyDefaultHierarchyTemplate=false
 #For publishing
 POM_URL=https://github.com/agrevster/pocketbase-kotlin

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,6 +14,7 @@ ktor-client-content-negociation = { module = "io.ktor:ktor-client-content-negoti
 ktor-serialization-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
 ktor-client-cio = { module = "io.ktor:ktor-client-cio", version.ref = "ktor" }
 ktor-client-winhttp = { module = "io.ktor:ktor-client-winhttp", version.ref = "ktor" }
+ktor-client-js = { module = "io.ktor:ktor-client-js", version.ref = "ktor" }
 
 
 #Kotlin sublibs

--- a/src/commonMain/kotlin/io/github/agrevster/pocketbaseKotlin/services/RealtimeService.kt
+++ b/src/commonMain/kotlin/io/github/agrevster/pocketbaseKotlin/services/RealtimeService.kt
@@ -4,14 +4,28 @@ import io.github.agrevster.pocketbaseKotlin.PocketbaseClient
 import io.github.agrevster.pocketbaseKotlin.PocketbaseException
 import io.github.agrevster.pocketbaseKotlin.services.utils.BaseService
 import io.github.agrevster.pocketbaseKotlin.toJsonPrimitive
-import io.ktor.client.plugins.sse.*
-import io.ktor.client.request.*
-import io.ktor.http.*
-import kotlinx.coroutines.*
+import io.ktor.client.plugins.sse.sse
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.contentType
+import io.ktor.http.path
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.cancelChildren
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.*
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.decodeFromJsonElement
 
 public class RealtimeService(client: PocketbaseClient) : BaseService(client) {
 
@@ -86,8 +100,8 @@ public class RealtimeService(client: PocketbaseClient) : BaseService(client) {
      *
      * @sample runBlocking { launch{ realtime.connect() } }
      */
-    public fun connect() {
-        runBlocking {
+    public suspend fun connect() {
+        coroutineScope {
             val job = launch {
                 if (connected) throw PocketbaseException("You are already connected to the realtime service!")
                 connected = true

--- a/src/commonTest/kotlin/TestUtils.kt
+++ b/src/commonTest/kotlin/TestUtils.kt
@@ -7,15 +7,15 @@ import io.github.agrevster.pocketbaseKotlin.models.Collection
 import io.github.agrevster.pocketbaseKotlin.models.Record
 import io.github.agrevster.pocketbaseKotlin.models.utils.BaseModel
 import io.github.agrevster.pocketbaseKotlin.models.utils.SchemaField
-import io.ktor.http.*
-import io.ktor.utils.io.core.*
+import io.ktor.http.URLProtocol
+import io.ktor.utils.io.core.toByteArray
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
-import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonPrimitive
 import kotlin.io.encoding.Base64
@@ -102,8 +102,9 @@ data class TestRecord(val name: String, val age: Int, val married: Boolean, @Tra
 }
 
 
-fun coroutine(block: suspend CoroutineScope.() -> Unit): Unit {
-    runBlocking {
+val backgroundScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+fun coroutine(block: suspend CoroutineScope.() -> Unit) {
+    backgroundScope.launch {
         block()
     }
 }

--- a/src/wasmJsMain/kotlin/io/github/agrevster/pocketbaseKotlin/Module.wasmJs.kt
+++ b/src/wasmJsMain/kotlin/io/github/agrevster/pocketbaseKotlin/Module.wasmJs.kt
@@ -1,0 +1,9 @@
+package io.github.agrevster.pocketbaseKotlin
+
+import io.ktor.client.HttpClient
+import io.ktor.client.HttpClientConfig
+import io.ktor.client.engine.js.Js
+
+internal actual fun httpClient(config: HttpClientConfig<*>.() -> Unit): HttpClient {
+    return HttpClient(Js) { config(this) }
+}


### PR DESCRIPTION
This PR adds support for wasmJs by:

- Adding the necessary configuration to `build.gradle.kts`
- Changing `RealtimeService#connect` to be suspend (since we can't use `runBlocking` is wasmJs)
- Adding the `httpClient` for `wasmJs`

Also bumps the version to `2.7.2`

### Tasks
- [x] Builds succeed
- [ ] All tests succeed

Fixes #10