### PR TITLE
fix: use Darwin engine for Apple targets to resolve TLS errors

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,7 +16,8 @@ repositories {
 
 enum class HttpClientType {
     WIN_HTTP,
-    CIO;
+    CIO,
+    DARWIN;
 }
 
 kotlin {
@@ -109,18 +110,30 @@ kotlin {
             }
         }
 
+        val darwinMain by creating {
+            dependsOn(commonMain.get())
+            dependencies {
+                api(libs.ktor.client.darwin)
+            }
+        }
+
+        val darwinTest by creating {
+            dependsOn(commonTest.get())
+            dependencies {
+                implementation(libs.ktor.client.darwin)
+            }
+        }
+
 
         fun KotlinSourceSet.configureDependencies(
             test: Boolean = false,
             httpClientType: HttpClientType = HttpClientType.CIO,
         ) {
-            if (httpClientType == HttpClientType.WIN_HTTP) {
-                if (test) {
-                    this.dependsOn(winHTTPTest)
-                } else this.dependsOn(winHTTPMain)
-            } else if (test) {
-                this.dependsOn(cioTest)
-            } else this.dependsOn(cioMain)
+            when (httpClientType) {
+                HttpClientType.WIN_HTTP -> if (test) dependsOn(winHTTPTest) else dependsOn(winHTTPMain)
+                HttpClientType.DARWIN -> if (test) dependsOn(darwinTest) else dependsOn(darwinMain)
+                HttpClientType.CIO -> if (test) dependsOn(cioTest) else dependsOn(cioMain)
+            }
         }
 
 
@@ -130,23 +143,20 @@ kotlin {
         getByName("linuxX64Main").configureDependencies()
         getByName("linuxX64Test").configureDependencies(test = true)
 
-        getByName("macosX64Main").configureDependencies()
-        getByName("macosX64Test").configureDependencies(test = true)
+        getByName("macosX64Main").configureDependencies(httpClientType = HttpClientType.DARWIN)
+        getByName("macosX64Test").configureDependencies(test = true, httpClientType = HttpClientType.DARWIN)
 
-        getByName("macosArm64Main").configureDependencies()
-        getByName("macosArm64Test").configureDependencies(test = true)
+        getByName("macosArm64Main").configureDependencies(httpClientType = HttpClientType.DARWIN)
+        getByName("macosArm64Test").configureDependencies(test = true, httpClientType = HttpClientType.DARWIN)
 
-        getByName("iosArm64Main").configureDependencies()
-        getByName("iosArm64Test").configureDependencies(test = true)
+        getByName("iosArm64Main").configureDependencies(httpClientType = HttpClientType.DARWIN)
+        getByName("iosArm64Test").configureDependencies(test = true, httpClientType = HttpClientType.DARWIN)
 
-        getByName("iosSimulatorArm64Main").configureDependencies()
-        getByName("iosSimulatorArm64Test").configureDependencies(test = true)
+        getByName("iosSimulatorArm64Main").configureDependencies(httpClientType = HttpClientType.DARWIN)
+        getByName("iosSimulatorArm64Test").configureDependencies(test = true, httpClientType = HttpClientType.DARWIN)
 
-        getByName("iosX64Main").configureDependencies()
-        getByName("iosX64Test").configureDependencies(test = true)
-
-        getByName("macosArm64Main").configureDependencies()
-        getByName("macosArm64Test").configureDependencies(test = true)
+        getByName("iosX64Main").configureDependencies(httpClientType = HttpClientType.DARWIN)
+        getByName("iosX64Test").configureDependencies(test = true, httpClientType = HttpClientType.DARWIN)
 
         getByName("mingwX64Main").configureDependencies(httpClientType = HttpClientType.WIN_HTTP)
         getByName("mingwX64Test").configureDependencies(test = true, httpClientType = HttpClientType.WIN_HTTP)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,6 +15,7 @@ ktor-client-content-negociation = { module = "io.ktor:ktor-client-content-negoti
 ktor-serialization-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
 ktor-client-cio = { module = "io.ktor:ktor-client-cio", version.ref = "ktor" }
 ktor-client-winhttp = { module = "io.ktor:ktor-client-winhttp", version.ref = "ktor" }
+ktor-client-darwin = { module = "io.ktor:ktor-client-darwin", version.ref = "ktor" }
 
 
 #Kotlin sublibs

--- a/src/darwinMain/kotlin/Module.darwin.kt
+++ b/src/darwinMain/kotlin/Module.darwin.kt
@@ -1,0 +1,8 @@
+package io.github.agrevster.pocketbaseKotlin
+
+import io.ktor.client.*
+import io.ktor.client.engine.darwin.*
+
+internal actual fun httpClient(config: HttpClientConfig<*>.() -> Unit): HttpClient {
+    return HttpClient(Darwin) { config(this) }
+}


### PR DESCRIPTION
CIO engine does not support TLS on Apple native platforms, causing 'TLS sessions are not supported on Native platform' errors on iOS/macOS.

- Add ktor-client-darwin dependency
- Create darwinMain source set with Darwin engine implementation
- Switch iOS and macOS targets from CIO to Darwin
- Remove duplicate macosArm64 source set configuration